### PR TITLE
FFS-1711: Remove Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,0 @@
-FROM gradle:7.5-jdk21 as builder
-USER root
-COPY . .
-RUN gradle --no-daemon build
-
-FROM gcr.io/distroless/java21
-ENV JAVA_TOOL_OPTIONS -XX:+ExitOnOutOfMemoryError
-COPY --from=builder /home/gradle/build/libs/fint-flyt-instance-gateway-*.jar /data/app.jar
-CMD ["/data/app.jar"]

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.springframework.boot.gradle.plugin.SpringBootPlugin
 
 plugins {
-    id("org.springframework.boot") version "3.5.7" apply false
+    id("org.springframework.boot") version "3.5.10" apply false
     id("io.spring.dependency-management") version "1.1.7"
     id("java")
     id("maven-publish")


### PR DESCRIPTION
- This repository is a library and doesn't need a Dockerfile.
- Bumping to latest Spring Boot 3.5 patch version.